### PR TITLE
fix: set criticality_rank to :unknown when criticality is nil

### DIFF
--- a/rdjson_formatter.rb
+++ b/rdjson_formatter.rb
@@ -4,6 +4,7 @@ require 'json'
 GEMFILE_LOCK_PATH = 'Gemfile.lock'
 
 CRITICALITY_RANK = {
+  unknown:  0,
   none:     0,
   low:      1,
   medium:   2,
@@ -29,7 +30,8 @@ diagnostics = results.map do |result|
     Solution: upgrade to #{result.dig('advisory', 'patched_versions').map{|v| "'#{v}'"}.join(', ')}
   EOS
 
-  criticality_rank     = CRITICALITY_RANK[result.dig('advisory', 'criticality').to_sym]
+  criticality          = result.dig('advisory', 'criticality') || :unknown
+  criticality_rank     = CRITICALITY_RANK[criticality.to_sym]
   max_criticality_rank = [max_criticality_rank, criticality_rank].max
 
   line = `grep -n -E '^\s{4}#{gem_name}' #{GEMFILE_LOCK_PATH} | cut -d : -f 1`.to_i


### PR DESCRIPTION
When bundler-audit outputs JSON with a criticality value of null, it causes an error.

Error:
```
/home/runner/work/_actions/kado-ta/bundler-audit-reviewdog/v1/rdjson_formatter.rb:32:in `block in <main>': undefined method `to_sym' for nil (NoMethodError)
  
criticality_rank     = CRITICALITY_RANK[result.dig('advisory', 'criticality').to_sym]
```

Example of bundler-audit output:
```
$ bundle exec bundler-audit check --format json 

{
  "version": "0.9.2",
  "created_at": "2025-02-14 16:00:12 +0900",
  "results": [
    {
      "type": "unpatched_gem",
      "gem": {
        "name": "rack",
        "version": "2.2.10"
      },
      "advisory": {
        "path": "/Users/youichiro.ogawa/.local/share/ruby-advisory-db/gems/rack/CVE-2025-25184.yml",
        "id": "CVE-2025-25184",
        "url": "https://github.com/rack/rack/security/advisories/GHSA-7g2v-jj9q-g3rg",
        "title": "Possible Log Injection in Rack::CommonLogger",
        "date": "2025-02-12",
        "description": "## Summary\n\n`Rack::CommonLogger` can be exploited by crafting input that includes\nnewline characters to manipulate log entries. The supplied\nproof-of-concept demonstrates injecting malicious content into logs.\n\n## Details\n\nWhen a user provides the authorization credentials via\n`Rack::Auth::Basic`, if success, the username will be put in\n`env['REMOTE_USER']` and later be used by `Rack::CommonLogger`\nfor logging purposes.\n\nThe issue occurs when a server intentionally or unintentionally\nallows a user creation with the username contain CRLF and white\nspace characters, or the server just want to log every login\nattempts. If an attacker enters a username with CRLF character,\nthe logger will log the malicious username with CRLF characters\ninto the logfile.\n\n## Impact\n\nAttackers can break log formats or insert fraudulent entries,\npotentially obscuring real activity or injecting malicious data\ninto log files.\n\n## Mitigation\n\n- Update to the latest version of Rack.\n",
        "cvss_v2": null,
        "cvss_v3": null,
        "cve": "2025-25184",
        "osvdb": null,
        "ghsa": "7g2v-jj9q-g3rg",
        "unaffected_versions": [

        ],
        "patched_versions": [
          "~> 2.2.11",
          "~> 3.0.12",
          ">= 3.1.10"
        ],
        "criticality": null
      }
    }
  ]
}
```

In such cases, criticality_rank should be set to "unknown".
The original repository has merged the same fix: https://github.com/thamdavies/action-bundler-audit/commit/e2fcb7d327234b10f96e1bad4852b11978482c9d